### PR TITLE
bugfix(grid.py) Need to pass angrot to set_coord_info() or else alway…

### DIFF
--- a/mfexport/grid.py
+++ b/mfexport/grid.py
@@ -22,7 +22,7 @@ class MFexportGrid(StructuredGrid):
         if xul is not None and yul is not None:
             xll = self._xul_to_xll(xul)
             yll = self._yul_to_yll(yul)
-            self.set_coord_info(xoff=xll, yoff=yll, epsg=epsg, proj4=proj_str)
+            self.set_coord_info(xoff=xll, yoff=yll, epsg=epsg, angrot=angrot, proj4=proj_str)
 
     def __eq__(self, other):
         if not isinstance(other, StructuredGrid):

--- a/mfexport/grid.py
+++ b/mfexport/grid.py
@@ -74,7 +74,7 @@ class MFexportGrid(StructuredGrid):
         """
         return Affine(self.delr[0], 0., self.xul,
                       0., -self.delc[0], self.yul) * \
-               Affine.rotation(angle=self.angrot)
+               Affine.rotation(angle=-self.angrot)
 
     @property
     def proj_str(self):

--- a/mfexport/grid.py
+++ b/mfexport/grid.py
@@ -74,7 +74,7 @@ class MFexportGrid(StructuredGrid):
         """
         return Affine(self.delr[0], 0., self.xul,
                       0., -self.delc[0], self.yul) * \
-               Affine.rotation(self.angrot)
+               Affine.rotation(-self.angrot)
 
     @property
     def proj_str(self):

--- a/mfexport/grid.py
+++ b/mfexport/grid.py
@@ -74,7 +74,7 @@ class MFexportGrid(StructuredGrid):
         """
         return Affine(self.delr[0], 0., self.xul,
                       0., -self.delc[0], self.yul) * \
-               Affine.rotation(-self.angrot)
+               Affine.rotation(angle=self.angrot)
 
     @property
     def proj_str(self):

--- a/mfexport/tests/test_rotation.py
+++ b/mfexport/tests/test_rotation.py
@@ -1,0 +1,8 @@
+import mfexport
+
+def test_grid_rotation():
+    m_lirm_grid = mfexport.MFexportGrid(delr=[100 for i in range(50)],
+                                    delc=[100 for i in range(50)],
+                                    xul=1954815, yul=219671,
+                                    epsg=4456, angrot=18.0)
+    assert m_lirm_grid.angrot == 18.0

--- a/mfexport/tests/test_rotation.py
+++ b/mfexport/tests/test_rotation.py
@@ -1,8 +1,17 @@
 import mfexport
+import numpy as np
 
 def test_grid_rotation():
-    m_lirm_grid = mfexport.MFexportGrid(delr=[100 for i in range(50)],
-                                    delc=[100 for i in range(50)],
+    angrot = 18
+    m_lirm_grid = mfexport.MFexportGrid(delr=[1309 for i in range(500)],
+                                    delc=[348 for i in range(500)],
                                     xul=1954815, yul=219671,
-                                    epsg=4456, angrot=18.0)
-    assert m_lirm_grid.angrot == 18.0
+                                    epsg=4456, angrot=angrot)
+    assert m_lirm_grid.angrot == angrot
+
+    m_lirm_ll = mfexport.MFexportGrid(delr=[1309 for i in range(500)],
+                            delc=[348 for i in range(500)],
+                            xoff=2008584, yoff=54187,
+                            epsg=4456, angrot=angrot)
+
+    assert np.allclose([m_lirm_grid.xul, m_lirm_grid.yul], [m_lirm_ll.xul, m_lirm_ll.yul])


### PR DESCRIPTION
…s gets reset to 0.0 on construction. This impacted MFexportGrid constructor.

Added a simple test as well